### PR TITLE
Add comment about extern crate and Rust editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ to the [Unicode Standard Annex #29](http://www.unicode.org/reports/tr29/) rules.
 [Documentation](https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/index.html)
 
 ```rust
-extern crate unicode_segmentation;
+// Uncomment this if you're using the Rust 2015 edition
+// extern crate unicode_segmentation;
 
 use unicode_segmentation::UnicodeSegmentation;
 


### PR DESCRIPTION
Closes #58.

Most users of this crate are on the Rust 2018 edition and no longer need the `extern crate` declaration. This README should encourage idiomatic Rust code, i.e. leaving out the extern crate declaration for Rust 2018 code.